### PR TITLE
Additional dependencies for Gentoo

### DIFF
--- a/Battle.Net.md
+++ b/Battle.Net.md
@@ -20,7 +20,7 @@ These dependencies may already be installed on your system, but it won't hurt to
 * Fedora: `gnutls gnutls-devel openldap openldap-devel libgpg-error sqlite2.i686 sqlite2.x86_64` (Both i686 and x86_64 versions)
 * Solus: `libgnutls libgnutls-devel libgnutls-32bit libgnutls-32bit-devel openldap-devel openldap-32bit-devel libgpg-error-devel libgpg-error-32bit libgpg-error-32bit-devel sqlite3 sqlite3-32bit`
 * OpenSuse: `libgnutls.so.30 libgnutls-devel libgnutls.so.28 libldap libgpg-error` (Or libgpg-error.so.0)
-* Gentoo: `gnutls libgpg-error sqlite`
+* Gentoo: `gnutls libgpg-error sqlite app-crypt/p11-kit sys-libs/readline libusb`, all with `abi_x86_32` enabled.
 
 ##  Known issues and troubleshooting
 Bugs, misconfigured systems and missing dependencies can sometimes cause issues with Battle.Net:


### PR DESCRIPTION
While installing battle.net using lutris on a fresh Gentoo install, i figured out that additional libraries are required - otherwise, battle.net won’t install.