### PR TITLE
Overwatch on BTRFS?

### DIFF
--- a/Overwatch.md
+++ b/Overwatch.md
@@ -1,6 +1,6 @@
 # Overwatch on Linux (Wine)
 
-**_Note: The game won't work correctly if it was installed on an NTFS partition. Please choose an Ext4 or BTRFS drive as destination instead._**
+**_Note: The game won't work correctly if it was installed on an NTFS partition._**
 
 ### Wine dependencies
 Wine dependencies are **required** for Overwatch to work. Please follow the instructions on [Wine Dependencies](https://github.com/lutris/docs/blob/master/WineDependencies.md) page to get them.

--- a/Overwatch.md
+++ b/Overwatch.md
@@ -1,6 +1,6 @@
 # Overwatch on Linux (Wine)
 
-**_Note: The game won't work correctly if it was installed on an NTFS or BTRFS partition. Please choose an Ext4 drive as destination instead._**
+**_Note: The game won't work correctly if it was installed on an NTFS partition. Please choose an Ext4 or BTRFS drive as destination instead._**
 
 ### Wine dependencies
 Wine dependencies are **required** for Overwatch to work. Please follow the instructions on [Wine Dependencies](https://github.com/lutris/docs/blob/master/WineDependencies.md) page to get them.


### PR DESCRIPTION
The old documentation says Overwatch does not work on BTRFS, but I personally can't find any example of this. I'm on the F33 beta right now and Overwatch seems to be working perfectly fine on BTRFS. Is this issue deprecated, or is something else at play (encryption etc.) Has anyone else tried bare metal as well?

Related Issue #28 mentions something similar, but it's been stale for quite a while now, so I'm submitting this PR.

If anyone else on BTRFS, OpenSuse, or F33 have experience/issues, please share!