### PR TITLE
Battle.Net: add lib32-alsa-plugins for Archlinux

### DIFF
--- a/Battle.Net.md
+++ b/Battle.Net.md
@@ -17,7 +17,7 @@ Otherwise, Battle.Net **may not work**.
 ### Additional dependencies required specifically for Battle.net:
 These dependencies may already be installed on your system, but it won't hurt to ensure you have them.
 * Ubuntu: `libgnutls30:i386 libldap-2.4-2:i386 libgpg-error0:i386 libsqlite3-0:i386`
-* Arch: `lib32-gnutls lib32-libldap lib32-libgpg-error lib32-sqlite lib32-libpulse`
+* Arch: `lib32-gnutls lib32-libldap lib32-libgpg-error lib32-sqlite lib32-libpulse lib32-alsa-plugins`
 * Fedora: `freetype.i686 gnutls.i686 openldap.i686 libgpg-error.i686 sqlite2.i686 pulseaudio-libs.i686`
 * Solus: `libgnutls libgnutls-devel libgnutls-32bit libgnutls-32bit-devel openldap-devel openldap-32bit-devel libgpg-error-devel libgpg-error-32bit libgpg-error-32bit-devel sqlite3 sqlite3-32bit`
 * OpenSuse: `libgnutls.so.30 libgnutls-devel libgnutls.so.28 libldap libgpg-error libvulkan_radeon-32bit` (Or libgpg-error.so.0)


### PR DESCRIPTION
I couldn't start Battle.Net on a brand new Arch install, tried everything because nothing was showing up in the logs, then I installed this package and it worked instantly.