### PR TITLE
Solus: Change wine-32bit-devel to wine-32bit

### DIFF
--- a/WineDependencies.md
+++ b/WineDependencies.md
@@ -87,7 +87,7 @@ Disclaimer: this may seem like a lot of libraries to install, but in order for g
 
 Execute following command:
 
-    sudo eopkg install wine wine-devel wine-32bit-devel winetricks
+    sudo eopkg install wine wine-devel wine-32bit winetricks
     
 ## Fedora
 


### PR DESCRIPTION
There's no longer wine-32bit-devel split in Solus.