### PR TITLE
Add more details to Battle.net docs regarding "A required DLL could not be found" error

### DIFF
--- a/Battle.Net.md
+++ b/Battle.Net.md
@@ -45,6 +45,12 @@ Also may be caused by not rebooting after installing drivers.
 If the message appears when DXVK is in use, and it works with DXVK disabled, make sure you installed Vulkan correctly, including 32 bit packages.
 If the issue persists, try removing Lutris's DXVK catalog in `.local/share/lutris/runtime/dxvk` (.local is a hidden folder inside your `Home` directory).
 
+If disabling DXVK doesn't work, it might be an issue with NTFS. Although NTFS is not recommended, the problem occurs due to how the Battle.net app checks for the required DLLs, which, for Windows, file names are case-insensitive, whereas for Linux, file names are case-sensitive. In other words, the app can't find the required DLLs because Linux treats those DLLs as case-sensitive and therefore the app won't launch.
+
+To fix it, try renaming the following files in `drive_c/Program Files (x86)/Battle.net/Battle.net.xxxxx` (where xxxxx is the latest version you have installed):
+- `msvcp140.dll` -> `MSVCP140.dll`
+- `vcruntime140.dll` -> `VCRUNTIME140.dll`
+
 ### Spinning Icon, no login buttons
 Go to options for Battle.Net - disable hardware acceleration.
 


### PR DESCRIPTION
I have installed World of Warcraft via Lutris about 2 weeks ago, and after a few days playing I started having this "A required DLL could not be found" error. I searched a lot and all the fixes were "disable DXVK" or "install the game on a non-NTFS formatted drive".

The former doesn't always work and the latter isn't an option for some users (like me). I decided to run the Battle.net app externally without Lutris (since Lutris doesn't show any helpful logs at all, saying which required DLLs are missing, for example) and found out that the problem is that the required DLLs don't have the proper casing in their filenames.

I filed a bug report to WineDB here: https://bugs.winehq.org/show_bug.cgi?id=52029

And I literally just renamed those 2 files to the casing the app expects them to be and I could open Battle.net once again.