### PR TITLE
Add support for Ubuntu 21.10

### DIFF
--- a/WineDependencies.md
+++ b/WineDependencies.md
@@ -21,6 +21,7 @@ Add the repository:
 
 |For this version: | Use this command:          
 |------------------|--------------------------------
+|Ubuntu 21.10      | sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ impish main'
 |Ubuntu 21.04      | sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ hirsute main'
 |Ubuntu 20.10      | sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ groovy main'
 |Ubuntu 20.04      | sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main'


### PR DESCRIPTION
WineHQ has added the `impish` repository for Ubuntu 21.10, so it should be added here to avoid end-user confusion.  I would also remove 18.10, 19.10, and 20.10 since they're no longer supported, but that's probably worthy of an actual discussion, this commit adding support for 21.10 should be pretty uncontroversial.