### PR TITLE
Replace 'opencl-icd-loader' with 'ocl-icd'

### DIFF
--- a/WineDependencies.md
+++ b/WineDependencies.md
@@ -35,7 +35,7 @@ sudo pacman -S --needed wine-staging giflib lib32-giflib libpng lib32-libpng lib
 mpg123 lib32-mpg123 openal lib32-openal v4l-utils lib32-v4l-utils libpulse lib32-libpulse libgpg-error \
 lib32-libgpg-error alsa-plugins lib32-alsa-plugins alsa-lib lib32-alsa-lib libjpeg-turbo lib32-libjpeg-turbo \
 sqlite lib32-sqlite libxcomposite lib32-libxcomposite libxinerama lib32-libgcrypt libgcrypt lib32-libxinerama \
-ncurses lib32-ncurses opencl-icd-loader lib32-opencl-icd-loader libxslt lib32-libxslt libva lib32-libva gtk3 \
+ncurses lib32-ncurses ocl-icd lib32-ocl-icd libxslt lib32-libxslt libva lib32-libva gtk3 \
 lib32-gtk3 gst-plugins-base-libs lib32-gst-plugins-base-libs vulkan-icd-loader lib32-vulkan-icd-loader
 ```
 


### PR DESCRIPTION
Arch packages 'opencl-icd-loader' and 'lib32-opencl-icd-loader' no longer exist and have been replaced by 'ocl-icd' and 'lib32-ocl-icd'.