### PR TITLE
Change Antergos to EndeavourOS.

### DIFF
--- a/WineDependencies.md
+++ b/WineDependencies.md
@@ -13,7 +13,7 @@ To do so in one command, copy and paste this into the terminal
 
     sudo dpkg --add-architecture i386 && sudo apt update && sudo apt install -y wine64 wine32 libasound2-plugins:i386 libsdl2-2.0-0:i386 libdbus-1-3:i386 libsqlite3-0:i386
 
-##  Arch/Antergos/Manjaro/Other Arch derivatives
+##  Arch/EndeavourOS/Manjaro/Other Arch derivatives
 
 Enable multilib:
 


### PR DESCRIPTION
Discontinued and succeeded by EndeavourOS.