### PR TITLE
Update InstallingDrivers.md

### DIFF
--- a/InstallingDrivers.md
+++ b/InstallingDrivers.md
@@ -174,7 +174,7 @@ Add the following lines to your NixOS hardware configuration, by default it shou
 
 ```
 boot.initrd.kernelModules = [ "nvidia" ]; 
-blacklistedKernelModules = ["nouveau"];
+boot.blacklistedKernelModules = ["nouveau"];
 ```
 Add the following lines to your NixOS configuration, by default it should be at ``/etc/nixos/configuration.nix`` (customize as you prefer)
 


### PR DESCRIPTION
Fix incorrect NixOS hardware setting

The current value of `blacklistedKernelModules` is incorrect and yields an error on NixOS version 23.05
```
# nixRebuild
error: The option `blacklistedKernelModules' does not exist. Definition values:
       - In `/etc/nixos/hardware-configuration.nix':
           [
             "nouveau"
           ]
(use '--show-trace' to show detailed location information)
```

The correct value is `boot.blacklistedKernelModules`, as seen in the [nvidia-optimus.nix](https://github.com/NixOS/nixpkgs/blob/nixos-23.05/nixos/modules/services/hardware/nvidia-optimus.nix#L25) file:
```
  config = lib.mkIf config.hardware.nvidiaOptimus.disable {
    boot.blacklistedKernelModules = ["nouveau" "nvidia" "nvidiafb" "nvidia-drm"];
<REST_OF_BODY>
 ```