### PR TITLE
Overwatch video saving workaround is outdated and doesnt work anymore

### DIFF
--- a/Overwatch.md
+++ b/Overwatch.md
@@ -22,7 +22,7 @@ Blizzard Battle.Net will be installed when you run the Lutris Installer for Over
 
 - The stuttering may persist/reappear if you play with settings higher than Low or there was a release of new content. Just spectate your friends/play a bit and it will disappear.
 
-- Highlights won't save (results in error). To workaround that, switch the format to WebM, as the issue is MP4 specific.
+- Highlights won't save (results in error). Previously you could work around this by manually selecting WEBM as a format, but that results in ~600KB corrupted files at this point. There is currently no known solution to saving videos in Overwatch on Linux.
 
 - If starting from Blizzard App crashes the game/you only see a black screen for quite a while now, you need to disable Streaming feature in Blizzard App
 


### PR DESCRIPTION
I got 3 other people who confirmed this. 

Me playing with Proton-GE on Steam, and used Lutris before with the same issue
A Friend who uses Nobara and plays through Bottles
2 people on the Lutris Discord, who I assume use Lutris @doogie544 (I think, name is extremely close)  with [this Message](https://discord.com/channels/512538904872747018/538903130704838656/1204869241484877884) and @An-Eagle with [this Message](https://discord.com/channels/512538904872747018/538903130704838656/1204881366068760576)