### PR TITLE
Update arch wine dependencies

### DIFF
--- a/WineDependencies.md
+++ b/WineDependencies.md
@@ -31,12 +31,11 @@ Upgrade your system:
 Execute the following command:
 
 ```
-sudo pacman -S --needed wine-staging giflib lib32-giflib libpng lib32-libpng libldap lib32-libldap gnutls lib32-gnutls \
-mpg123 lib32-mpg123 openal lib32-openal v4l-utils lib32-v4l-utils libpulse lib32-libpulse libgpg-error \
-lib32-libgpg-error alsa-plugins lib32-alsa-plugins alsa-lib lib32-alsa-lib libjpeg-turbo lib32-libjpeg-turbo \
-sqlite lib32-sqlite libxcomposite lib32-libxcomposite libxinerama lib32-libgcrypt libgcrypt lib32-libxinerama \
-ncurses lib32-ncurses ocl-icd lib32-ocl-icd libxslt lib32-libxslt libva lib32-libva gtk3 \
-lib32-gtk3 gst-plugins-base-libs lib32-gst-plugins-base-libs vulkan-icd-loader lib32-vulkan-icd-loader
+sudo pacman -S wine-staging
+sudo pacman -S --needed --asdeps giflib lib32-giflib gnutls lib32-gnutls v4l-utils lib32-v4l-utils libpulse \
+lib32-libpulse alsa-plugins lib32-alsa-plugins alsa-lib lib32-alsa-lib sqlite lib32-sqlite libxcomposite \
+lib32-libxcomposite ocl-icd lib32-ocl-icd libva lib32-libva gtk3 lib32-gtk3 gst-plugins-base-libs \
+lib32-gst-plugins-base-libs vulkan-icd-loader lib32-vulkan-icd-loader sdl2 lib32-sdl2
 ```
 
 Disclaimer: this may seem like a lot of libraries to install, but in order for games to install and work correctly, you will need them.

--- a/WineDependencies.md
+++ b/WineDependencies.md
@@ -28,7 +28,7 @@ Upgrade your system:
 
     sudo pacman -Syu 
 
-Execute the following command:
+Execute the following commands:
 
 ```
 sudo pacman -S wine-staging


### PR DESCRIPTION
They should be installed with `--asdeps`, because they are dependencies of wine.

Added `sdl2`.

The following are no longer needed: `ldap`, `openal`, `mpg123`, `openal`, `libjpeg-turbo`, `ncurses`, `libxslt`:

https://www.winehq.org/announce/6.0
https://www.winehq.org/announce/7.0
https://www.winehq.org/announce/8.0

`libxinerama` is apparently obsolete and should not be used: https://wiki.winehq.org/Building_Wine#Satisfying_Build_Dependencies

The patch that required libgcrypt was removed in wine-staging 9.0: https://gitlab.winehq.org/wine/wine-staging/-/commit/66c86503bdcb19dbe4348b4162672a14a4b60800

I'm not sure about `libgpg-error`, but it was removed from the ubuntu instructions b47aa0c45c7b7c3fa9993fb2808b863a8ebfc0c7 

I'm also not sure why it wanted `sqlite`, but this was never mentioned on the wine wiki page so I've removed it too.