### PR TITLE
Update info about Overwatch Highlight saving on Linux

### DIFF
--- a/Overwatch.md
+++ b/Overwatch.md
@@ -22,7 +22,7 @@ Blizzard Battle.Net will be installed when you run the Lutris Installer for Over
 
 - The stuttering may persist/reappear if you play with settings higher than Low or there was a release of new content. Just spectate your friends/play a bit and it will disappear.
 
-- Highlights won't save (results in error). Previously you could work around this by manually selecting WEBM as a format, but that results in ~600KB corrupted files at this point. There is currently no known solution to saving videos in Overwatch on Linux.
+- Highlights won't save (results in error) under some circumstances. The only way to get it working is by manually selecting WEBM as the format and then leaving it be until it is done. If you switch focus to another program via ALT+TAB or anything else it will result in an error as well.
 
 - If starting from Blizzard App crashes the game/you only see a black screen for quite a while now, you need to disable Streaming feature in Blizzard App
 


### PR DESCRIPTION
This is a followup on #156 in a way.

One of my friends that confirmed that this function used to be broken even with WEBM, no matter the machine or proton version (Check linked PR), made me aware that the WEBM method works again.

I just tried it and made another friend try it as well, and yes, it works again if using specifically WEBM. 

I updated the section according to that, feel free to change or rephrase it however you want.
