### PR TITLE
Update WineBuilds.md

### DIFF
--- a/WineBuilds.md
+++ b/WineBuilds.md
@@ -1,5 +1,5 @@
 # Wine Builds
 
-Lutris uses [Wine-GE-Proton](https://www.retroarch.com/) as the default Wine build. You can use other wine builds at your own risk.
+Lutris uses [Wine-GE-Proton](https://github.com/GloriousEggroll/wine-ge-custom) as the default Wine build. You can use other wine builds at your own risk.
 
 For League Of Legends and other games using the Riot Games launcher, use the LoL specific build.


### PR DESCRIPTION
Wine-GE-Proton URL fixed. Now links to GE repository instead of RetroArch website.