### PR TITLE
Update SDL package names for Arch Linux

### DIFF
--- a/WineDependencies.md
+++ b/WineDependencies.md
@@ -35,7 +35,7 @@ sudo pacman -S wine-staging
 sudo pacman -S --needed --asdeps giflib lib32-giflib gnutls lib32-gnutls v4l-utils lib32-v4l-utils libpulse \
 lib32-libpulse alsa-plugins lib32-alsa-plugins alsa-lib lib32-alsa-lib sqlite lib32-sqlite libxcomposite \
 lib32-libxcomposite ocl-icd lib32-ocl-icd libva lib32-libva gtk3 lib32-gtk3 gst-plugins-base-libs \
-lib32-gst-plugins-base-libs vulkan-icd-loader lib32-vulkan-icd-loader sdl2 lib32-sdl2
+lib32-gst-plugins-base-libs vulkan-icd-loader lib32-vulkan-icd-loader sdl2-compat lib32-sdl2-compat
 ```
 
 Disclaimer: this may seem like a lot of libraries to install, but in order for games to install and work correctly, you will need them.


### PR DESCRIPTION
Arch Linux now provides `sdl3` and has renamed `sdl2` to `sdl2-compat` and `lib32-sdl2` to `lib32-sdl2-compat`. Installing these packages will also install `sdl3` and `lib32-sdl3` as dependencies.