### PR TITLE
Update and rename WineBuilds.md to ProtonVersions.md

### DIFF
--- a/ProtonVersions.md
+++ b/ProtonVersions.md
@@ -1,0 +1,12 @@
+# Proton Version Management
+
+Lutris uses the deprecated [Wine-GE-8-26](https://github.com/GloriousEggroll/wine-ge-custom) as the default Wine build. 
+
+It is recommended to use up-to-date Proton versions that are likely to support more games. Use a tool like [ProtonPlus](https://github.com/Vysp3r/ProtonPlus) to easily install these.
+Then configure your Wine runner to use an up-to-date version (Runners > Wine > Manage Versions > "Wine Version"). 
+
+If you run into problems, use tools like [ProtonDB](https://www.protondb.com/) to check which Proton version works best with your game.
+Then override the Proton version for that specific game (Right Click Game > Configure > Runner Options > "Wine Version").
+Also make sure the [umu-launcher](https://github.com/Open-Wine-Components/umu-launcher) dependency is installed on your system. This will ensure ProtonFixes are applied to all games when run outside of Steam. E.g. on Arch systems this is an optional dependency that must be explicitly installed via the system package manager.
+
+

--- a/WineBuilds.md
+++ b/WineBuilds.md
@@ -1,5 +1,0 @@
-# Wine Builds
-
-Lutris uses [Wine-GE-Proton](https://github.com/GloriousEggroll/wine-ge-custom) as the default Wine build. You can use other wine builds at your own risk.
-
-For League Of Legends and other games using the Riot Games launcher, use the LoL specific build.


### PR DESCRIPTION
I updated the description on Proton versions for the Wine runner.

The current behaviour of Lutris combined with the state of the documentation is very confusing for newcomers, as many games will be broken by the age-old wine build used by Lutris by default. Additionally, the updater GUI does not provide any other builds. 

I added the information that I researched myself and got provided by the comunity on the Discord to make the onboarding process easier for other newcomers.

- Mention that Lutris uses an outdated Wine build by default
- Explain how to obtain up-to-date Proton versions (ProtonPlus)
- Mention ProtonDB and umu-launcher for troubleshooting
- LOL does not work anymore on Linux systems due to Vanguard, so there are no LOL-builds anymore. I removed this section.

The `!wineversions` command on the Discord should be updated, as it does not reflect the functionality of the software anymore.